### PR TITLE
Updated to allow for a tree with subtypes to all exist together

### DIFF
--- a/test/models/sub_category.rb
+++ b/test/models/sub_category.rb
@@ -1,0 +1,3 @@
+class SubCategory < Category
+
+end

--- a/test/test_tree.rb
+++ b/test/test_tree.rb
@@ -9,9 +9,9 @@ class TestMongoidActsAsTree < Test::Unit::TestCase
       @root_1     = Category.create(:name => "Root 1")
       @child_1    = Category.create(:name => "Child 1")
       @child_2    = Category.create(:name => "Child 2")
-      @child_2_1  = Category.create(:name => "Child 2.1")
+      @child_2_1  = SubCategory.create(:name => "Child 2.1")
 
-      @child_3    = Category.create(:name => "Child 3")
+      @child_3    = SubCategory.create(:name => "Child 3")
       @root_2     = Category.create(:name => "Root 2")
 
       @root_1.children << @child_1


### PR DESCRIPTION
There is now an option that defaults to mixing in class that sets the tree class to operate on.  Also laxed the equality check to look for a kind of the base class instead of an instance of the class.
